### PR TITLE
gitlab-ci home link always points into "/"

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,8 +11,7 @@
     .navbar.navbar-fixed-top.navbar-ci
       .navbar-inner
         .container-fluid
-          %a.brand{:href => "/"}
-            GitLab CI
+          = link_to 'GitLab CI', root_path, class: "brand"
           %ul.nav
             - if current_user
               %li


### PR DESCRIPTION
When application is deployed into sub-URI homepage points into "/", this pull request fixes this issue.
