### PR TITLE
Don't need restart nginx to reload configuration

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -116,9 +116,9 @@ Make sure to edit the config file to match your setup:
     # of your host serving GitLab CI
     sudo vim /etc/nginx/sites-enabled/gitlab_ci
 
-## Restart
+## Reload configuration
 
-    sudo /etc/init.d/nginx restart
+    sudo /etc/init.d/nginx reload
 
 
 # Done!


### PR DESCRIPTION
Also --no-check-certificate added to wget tool (to prevent certificate warnings)
