### PR TITLE
Pass the build ref to build scripts

### DIFF
--- a/lib/runner.rb
+++ b/lib/runner.rb
@@ -84,7 +84,8 @@ class Runner
     @process.environment['BUNDLE_GEMFILE'] = File.join(path, 'Gemfile')
     @process.environment['BUNDLE_BIN_PATH'] = ''
     @process.environment['RUBYOPT'] = ''
-
+    @process.environment['CI_BUILD_REF'] = build.ref
+    
     @process.start
 
     build.set_file @tmp_file.path


### PR DESCRIPTION
As a possible solution for https://github.com/gitlabhq/gitlab-ci/issues/74, would allow scripts to perform actions based on the branch
