### PR TITLE
fix the incompatible character encodings: ASCII-8BIT and UTF-8 error when showing output

### DIFF
--- a/app/views/builds/show.html.haml
+++ b/app/views/builds/show.html.haml
@@ -67,7 +67,7 @@
       .clearfix
     %pre.trace#build-trace
       = preserve do
-        = raw @build.trace_html
+        = raw(@build.trace_html).encode(Encoding.find('ASCII'), {invalid: :replace, undef: :replace, replace: '', universal_newline: true })
 
   .span3
     .builds


### PR DESCRIPTION
Make sure the output is clean so that you can view the build log. else...nothing is shown.
