### PR TITLE
Split output lines

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -4,6 +4,8 @@ class Build < ActiveRecord::Base
   attr_accessible :project_id, :ref, :sha, :before_sha,
     :status, :finished_at, :trace, :started_at
 
+  OUTPUT_LENGTH = 100
+
   validates :sha, presence: true
   validates :ref, presence: true
   validates :status, presence: true
@@ -94,6 +96,17 @@ class Build < ActiveRecord::Base
 
   def trace_html
     html = Ansi2html::convert(compose_output) if trace.present?
+
+    if html.present?
+      html = html.split("\n").map do |line|
+        if line.length > OUTPUT_LENGTH
+          line.scan(/.{1,#{OUTPUT_LENGTH}}/).join("\n")
+        else
+          line
+        end
+      end.join("\n")
+    end
+
     html ||= ''
   end
 

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -27,6 +27,28 @@ describe Build do
       build.ci_skip?.should == false
     end
   end
+
+  describe '#trace_html' do
+    context 'splitting' do
+      let(:build) { Build.new(trace: 'trace') }
+
+      it 'returns empty line' do
+        Ansi2html.stub(convert: '')
+        expect(build.trace_html).to eql('')
+      end
+
+      it "returns line less #{Build::OUTPUT_LENGTH} chars" do
+        Ansi2html.stub(convert: 'output')
+        expect(build.trace_html).to eql('output')
+      end
+
+      it "returns splitted line for length more #{Build::OUTPUT_LENGTH} chars" do
+        output = 'a' * (Build::OUTPUT_LENGTH + 10)
+        Ansi2html.stub(convert: output)
+        expect(build.trace_html).to eql("#{'a' * Build::OUTPUT_LENGTH}\n#{'a' * 10}")
+      end
+    end
+  end
 end
 
 


### PR DESCRIPTION
When CI starts tests the output lines are too long. It is necessary to use horizontal scroll to see results. It is very inconvenient when an application has a lot of tests and output has a loooong line with statuses (. or F).

I think it will be good to split the output lines by N chars.
