### PR TITLE
Allow connection to Redis via unix socket

### DIFF
--- a/config/initializers/2_sidekiq.rb
+++ b/config/initializers/2_sidekiq.rb
@@ -4,19 +4,19 @@ config_file = Rails.root.join('config', 'resque.yml')
 resque_url = if File.exists?(config_file)
                YAML.load_file(config_file)[Rails.env]
              else
-               "localhost:6379"
+               "redis://localhost:6379"
              end
 
 Sidekiq.configure_server do |config|
   config.redis = {
-    url: "redis://#{resque_url}",
+    url: resque_url,
     namespace: 'resque:gitlab_ci'
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-    url: "redis://#{resque_url}",
+    url: resque_url,
     namespace: 'resque:gitlab_ci'
   }
 end

--- a/config/resque.yml.example
+++ b/config/resque.yml.example
@@ -1,3 +1,3 @@
-development: localhost:6379
-test: localhost:6379
-production: redis.example.com:6379
+development: redis://localhost:6379
+test: redis://localhost:6379
+production: redis://redis.example.com:6379


### PR DESCRIPTION
Allow connection to Redis via unix socket, using
unix:/var/run/redis/redis.sock for example.

Default behaviour does not change, except that the full Redis URL must
be configured, with redis:// for tcp or unix: for unix socket.

See also: https://github.com/gitlabhq/gitlabhq/pull/3159
