### PR TITLE
Fix Build#duration when TimeZone is not UTC

### DIFF
--- a/app/helpers/builds_helper.rb
+++ b/app/helpers/builds_helper.rb
@@ -2,7 +2,7 @@ module BuildsHelper
   def build_duration build
     if build.started?
       from = build.started_at
-      to = build.finished_at || Time.now
+      to = build.finished_at || Time.zone.now
       distance_of_time_in_words(from, to)
     end
   end


### PR DESCRIPTION
I got wrong Build#durations, cause ServerTime is not UTC.

Sample Output:

```
$: build.from
=> Sat, 30 Mar 2013 16:58:42 UTC +00:00

$: Time.now
 => 2013-03-30 18:20:25 +0100

$: Time.zone.now
 => Sat, 30 Mar 2013 17:20:29 UTC +00:00
```

Using `Tome.zone.now` instead of `Time.now` fix this issue.
