### PR TITLE
Bumps rugged to version 0.18.0.b1, resolving GPG issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem 'whenever', require: false
 gem 'stamp'
 
 # Git support
-gem 'rugged', '~> 0.17.0.b7'
+gem 'rugged', '~> 0.18.0.b1'
 
 # Pagination
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
       rspec-expectations (~> 2.13.0)
       rspec-mocks (~> 2.13.0)
     rubyzip (0.9.9)
-    rugged (0.17.0.b7)
+    rugged (0.18.0.gh.de28323)
     sass (3.2.7)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
@@ -274,7 +274,7 @@ DEPENDENCIES
   rb-fsevent
   rb-inotify
   rspec-rails
-  rugged (~> 0.17.0.b7)
+  rugged (~> 0.18.0.b1)
   sass-rails (~> 3.2.3)
   settingslogic
   shoulda-matchers


### PR DESCRIPTION
Hey there!

I discovered another bug with GPG-signed commits while rolling out Gitlab CI at my workplace.

GPG signatures slip through the parsing and are displayed as part of the commit message:
![Bildschirmfoto 2013-04-20 um 14 57 51](https://f.cloud.github.com/assets/690188/405155/952ac608-a9bb-11e2-8257-5f73a07f9ed1.png)

This issue has been resolved in [libgit2/rugged #1255](https://github.com/libgit2/libgit2/pull/1255) three months ago and is included in the most recent pre-release version of the rugged gem:

![Bildschirmfoto 2013-04-20 um 15 12 15](https://f.cloud.github.com/assets/690188/405161/f796bca2-a9bb-11e2-8c04-0c8da8718b52.png)
