### PR TITLE
Serving gravatar images form an https source

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   end
 
   def gravatar_icon(user_email = '', size = 40)
-    gravatar_url = 'http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm'
+    gravatar_url = 'https://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm'
     user_email.strip!
     sprintf gravatar_url, hash: Digest::MD5.hexdigest(user_email.downcase), size: size
   end


### PR DESCRIPTION
This is safe to run on gitlab-ci http and https servers.

Fixes Issue #161
