### PR TITLE
doc: installation: add instructions to modify trace after the db is set up

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -76,6 +76,13 @@ Create a user for GitLab:
     #
     bundle exec rake db:setup RAILS_ENV=production
 
+    # fixing build trace output being cut off too early (after 2^16 bytes)
+    # ruby does not support longtext (2^32 bytes), so we have to do it here
+    #
+    $ mysql -u root -p
+    mysql> USE gitlab_ci_production;
+    mysql> ALTER TABLE builds MODIFY trace LONGTEXT;
+
     # Setup scedules 
     #
     bundle exec whenever -w RAILS_ENV=production


### PR DESCRIPTION
I am not a ruby hack, so please feel free to correct me here:
As far as I know ruby does not support longtext as a datatype, or rather
Active Record does not support it. This means that we have to change the
Datatype after the database was created in order to prevent build outputs
being cut off after 2^16 bytes (text). This commit instructs the user to
change the trace column after it was created to longtext (2^32 bytes)
which works flawless for me.

Ruby reference: http://guides.rubyonrails.org/migrations.html
Mysql reference: http://dev.mysql.com/doc/refman/5.0/en/storage-requirements.html

This fixes Issue #145

Signed-off-by: Dennis Rassmann showp1984@gmail.com
