### PR TITLE
builds: add additional autoscroll button below the build trace

### DIFF
--- a/app/assets/javascripts/builds.js.coffee
+++ b/app/assets/javascripts/builds.js.coffee
@@ -1,12 +1,28 @@
 $(document).ready ->
-  $("#autoscroll-button").bind "click", ->
+  $("#autoscroll-button_top").bind "click", ->
     state = $(this).data("state")
     if "enabled" is state
       $(this).data "state", "disabled"
       $(this).text "enable autoscroll"
+      $("#autoscroll-button_bot").data "state", "disabled"
+      $("#autoscroll-button_bot").text "enable autoscroll"
     else
       $(this).data "state", "enabled"
       $(this).text "disable autoscroll"
+      $("#autoscroll-button_bot").data "state", "enabled"
+      $("#autoscroll-button_bot").text "disable autoscroll"
+  $("#autoscroll-button_bot").bind "click", ->
+    state = $(this).data("state")
+    if "enabled" is state
+      $(this).data "state", "disabled"
+      $(this).text "enable autoscroll"
+      $("#autoscroll-button_top").data "state", "disabled"
+      $("#autoscroll-button_top").text "enable autoscroll"
+    else
+      $(this).data "state", "enabled"
+      $(this).text "disable autoscroll"
+      $("#autoscroll-button_top").data "state", "enabled"
+      $("#autoscroll-button_top").text "disable autoscroll"
 
 
 @getBuild = (buildPath, buildId) ->
@@ -16,4 +32,4 @@ $(document).ready ->
   ), 3000
 
 @checkAutoscroll = ->
-  $("html,body").scrollTop $("#build-trace").height()  if "enabled" is $("#autoscroll-button").data("state")
+  $("html,body").scrollTop $("#build-trace").height()  if "enabled" is $("#autoscroll-button_top").data("state")

--- a/app/views/builds/show.html.haml
+++ b/app/views/builds/show.html.haml
@@ -63,11 +63,16 @@
     .clearfix
     - if @build.active?
       .autoscroll-container.pull-right
-        %button.btn.btn-mini#autoscroll-button{:type => "button", :data => {:state => 'disabled'}} enable autoscroll
+        %button.btn.btn-mini#autoscroll-button_top{:type => "button", :data => {:state => 'disabled'}} enable autoscroll
       .clearfix
     %pre.trace#build-trace
       = preserve do
         = raw @build.trace_html
+    .clearfix
+    - if @build.active?
+      .autoscroll-container.pull-right
+        %button.btn.btn-mini#autoscroll-button_bot{:type => "button", :data => {:state => 'disabled'}} enable autoscroll
+      .clearfix
 
   .span3
     .builds


### PR DESCRIPTION
This allows disabling the autoscroll function from the bottom of the
build trace. It seriously annoyed me that it was always scrolling back
down once I got up to disable the feature. ^^

Signed-off-by: Dennis Rassmann showp1984@gmail.com
