### PR TITLE
Introduced $USER var for running the service as

### DIFF
--- a/lib/support/init.d/gitlab_ci
+++ b/lib/support/init.d/gitlab_ci
@@ -14,8 +14,8 @@
 # Description:       GitLab CI
 ### END INIT INFO
 
-
-APP_ROOT="/home/gitlab_ci/gitlab-ci"
+APP_USER="gitlab_ci"
+APP_ROOT="/home/$APP_USER/gitlab-ci"
 DAEMON_OPTS="-C $APP_ROOT/config/puma.rb -e production"
 PID_PATH="$APP_ROOT/tmp/pids"
 WEB_SERVER_PID="$PID_PATH/puma.pid"
@@ -45,8 +45,8 @@ start() {
     exit 1
   else
     if [ `whoami` = root ]; then
-      sudo -u gitlab_ci -H bash -l -c "RAILS_ENV=production bundle exec puma $DAEMON_OPTS"
-      sudo -u gitlab_ci -H bash -l -c "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
+      sudo -u $APP_USER -H bash -l -c "RAILS_ENV=production bundle exec puma $DAEMON_OPTS"
+      sudo -u $APP_USER -H bash -l -c "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
       echo "$DESC started"
     fi
   fi
@@ -58,7 +58,7 @@ stop() {
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     ## Program is running, stop it.
     kill -QUIT `cat $WEB_SERVER_PID`
-    sudo -u gitlab_ci -H bash -l -c "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
+    sudo -u $APP_USER -H bash -l -c "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
     rm "$WEB_SERVER_PID" >> /dev/null
     echo "$DESC stopped"
   else
@@ -74,9 +74,9 @@ restart() {
   if [ "$PID" -ne 0 -a "$STATUS" -ne 0 ]; then
     echo "Restarting $DESC..."
     kill -USR2 `cat $WEB_SERVER_PID`
-    sudo -u gitlab_ci -H bash -l -c "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
+    sudo -u $APP_USER -H bash -l -c "mkdir -p $PID_PATH && $STOP_SIDEKIQ  > /dev/null  2>&1 &"
     if [ `whoami` = root ]; then
-      sudo -u gitlab_ci -H bash -l -c "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
+      sudo -u $APP_USER -H bash -l -c "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
     fi
     echo "$DESC restarted."
   else
@@ -123,7 +123,7 @@ case "$1" in
         status
         ;;
   *)
-        echo "Usage: sudo service gitlab {start|stop|restart|reload}" >&2
+        echo "Usage: sudo service gitlab_ci {start|stop|restart|reload}" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
gitlab_ci was hardcoded as the user to run gitlab-ci as, replaced it with a variable at the top.
