### PR TITLE
Adding a project_id index to builds

### DIFF
--- a/db/migrate/20130628142321_add_index_project_id_to_builds.rb
+++ b/db/migrate/20130628142321_add_index_project_id_to_builds.rb
@@ -1,0 +1,5 @@
+class AddIndexProjectIdToBuilds < ActiveRecord::Migration
+  def change
+    add_index :builds, :project_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130603161449) do
+ActiveRecord::Schema.define(:version => 20130628142321) do
 
   create_table "builds", :force => true do |t|
     t.integer  "project_id"
@@ -28,6 +28,8 @@ ActiveRecord::Schema.define(:version => 20130603161449) do
     t.text     "push_data"
     t.integer  "runner_id"
   end
+
+  add_index "builds", ["project_id"], :name => "index_builds_on_project_id"
 
   create_table "projects", :force => true do |t|
     t.string   "name",                                :null => false


### PR DESCRIPTION
Hi, 

We were seeing a lot of slowdown viewing project pages on our internal gitlab ci instance when we started to get a lot of builds, so I have added a project_id index to the builds table, which seems to have comfortably resolved the issue.

Thanks,
Reuben.
