### PR TITLE
List all users projects, not just the projects they own.

### DIFF
--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -16,7 +16,7 @@ class Network
     end
   end
 
-  def projects(url, api_opts, scope = :owned)
+  def projects(url, api_opts, scope = :public)
     opts = {
       query: api_opts.merge(per_page: 1000),
       headers: {"Content-Type" => "application/json"},

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -44,7 +44,7 @@ class Project < ActiveRecord::Base
 
   before_validation :set_default_values
 
-  def self.from_gitlab(user, scope = :owned)
+  def self.from_gitlab(user, scope = :public)
     opts = {
       private_token: user.private_token
     }


### PR DESCRIPTION
Currently, the `/projects/gitlab` page only shows projects the user is the owner of.  The following change makes it so all of the user's projects are listed.

This seems to be a more sensible default perhaps, but I'm not super familiar with Ruby, so perhaps this isn't the right way to do it.
