### PR TITLE
Fix large push data getting truncated

### DIFF
--- a/db/migrate/20130816201200_change_push_data_limit.rb
+++ b/db/migrate/20130816201200_change_push_data_limit.rb
@@ -1,0 +1,5 @@
+class ChangePushDataLimit < ActiveRecord::Migration
+  def change
+    change_column :builds, :push_data, :text, :limit => 16777215
+  end
+end


### PR DESCRIPTION
This fixes random 500 when hooked diff is too large.
Closes #258

Changing huge amount of files or sending diff over multiple commits might result in a payload that is larger than MySQL text size (65,535 bytes, ~64kb). This patch (presumably) changes the column type to `mediumtext` with a size of `16,777,215 bytes, ~16MB).

I'm no rybyist so please double check the migration is all right.
