### PR TITLE
Add display name to runner model

### DIFF
--- a/app/models/runner.rb
+++ b/app/models/runner.rb
@@ -2,11 +2,12 @@
 #
 # Table name: runners
 #
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  public_key :text
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :integer          not null, primary key
+#  token       :string(255)
+#  public_key  :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :string(255)
 #
 
 class Runner < ActiveRecord::Base
@@ -41,5 +42,11 @@ class Runner < ActiveRecord::Base
   rescue => ex
     logger.warn "Assign runner to project failed: #{ex}"
     false
+  end
+
+  def display_name
+    return token unless !description.blank?
+
+    description
   end
 end

--- a/app/views/runner_projects/index.html.haml
+++ b/app/views/runner_projects/index.html.haml
@@ -7,7 +7,7 @@
     %table.table
       %tr
         %th Runner ID
-        %th Runner Token
+        %th Runner Description
         %th Last build
         %th Builds Stats
         %th Registered
@@ -20,7 +20,7 @@
           %td
             %span.badge.badge-info= runner.id
           %td
-            = runner.token
+            = runner.display_name
           %td
             - last_build = builds.last
             - if last_build

--- a/spec/models/runner_spec.rb
+++ b/spec/models/runner_spec.rb
@@ -2,15 +2,31 @@
 #
 # Table name: runners
 #
-#  id         :integer          not null, primary key
-#  token      :string(255)
-#  public_key :text
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :integer          not null, primary key
+#  token       :string(255)
+#  public_key  :text
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  description :string(255)
 #
 
 require 'spec_helper'
 
 describe Runner do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#display_name' do
+    it 'should return the description if it has a value' do
+      runner = FactoryGirl.build(:runner, description: 'Linux/Ruby-1.9.3-p448')
+      expect(runner.display_name).to eq 'Linux/Ruby-1.9.3-p448'
+    end
+
+    it 'should return the token if it does not have a description' do
+      runner = FactoryGirl.build(:runner)
+      expect(runner.display_name).to eq runner.token
+    end
+
+    it 'should return the token if the description is an empty string' do
+      runner = FactoryGirl.build(:runner, description: '')
+      expect(runner.display_name).to eq runner.token
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a method to the runner model that will return a display
name for the runner. It will return the runner's token if a runner
doesn't have a description or if it's empty. It will return the
description otherwise. This is in order to give each particular runner a
more friendly name when viewing them on a particular project. This
commit also updates the runner_projects index to use this display name
instead of using the token. And finally it adds spec tests to cover the
new method added.
