### PR TITLE
Update example application yaml

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -3,8 +3,7 @@ defaults: &defaults
     - 'https://dev.gitlab.org/'
     - 'https://staging.gitlab.org/'
   gitlab_ci:
-    https:
-      enabled: false
+    https: false
   gravatar:
     enabled: true
     plain_url: "http://www.gravatar.com/avatar/%{hash}?s=%{size}&d=mm"


### PR DESCRIPTION
This commit updates the example application yaml to reflect the change
made in the gravatar icon helper method. It removes enabled from
https and instead uses https to store the boolean value.
