### PR TITLE
Extending Runners API to include GET /runners call

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -172,6 +172,28 @@ Parameters:
 
 ## Runners
 
+### Retrieve all runners
+
+Used to get information about all runners registered on the Gitlab CI
+instance.
+
+    GET /runners
+
+Returns:
+
+```json
+[
+  {
+    "id" : 85,
+    "token" : "12b68e90394084703135"
+  },
+  {
+    "id" : 86,
+    "token" : "76bf894e969364709864"
+  },
+]
+```
+
 ### Register a new runner
 
 Used to make Gitlab CI aware of available runners.

--- a/lib/api/runners.rb
+++ b/lib/api/runners.rb
@@ -2,9 +2,25 @@ module API
   # Runners API
   class Runners < Grape::API
     resource :runners do
-      before { authenticate_runners! }
+      # Get list of all available runners
+      #
+      # Example Request:
+      #   GET /runners
+      get do
+        authenticate!
+        runners = Runner.all
+
+        if runners.present?
+          present runners, with: Entities::Runner
+        else
+          not_found!
+        end
+      end
 
       # Register a new runner
+      #
+      # Note: This is an "internal" API called when setting up
+      # runners, so it is authenticated differently.
       #
       # Parameters:
       #   token (required) - The unique token of runner
@@ -13,6 +29,7 @@ module API
       # Example Request:
       #   POST /runners/register
       post "register" do
+        authenticate_runners!
         required_attributes! [:token, :public_key]
 
         runner = Runner.create(public_key: params[:public_key])


### PR DESCRIPTION
The purpose of this pull request is for the automation of setting up a new project with a runner.  

The `GET /runners` call retrieves a list of all runners registered on the Gitlab CI instance.

Currently, there is no way of finding the ID of an existing runner using the API.  Since all projects need to be linked to a runner with a known ID, this pull request provides a way to look up that information.

The following can now be utilized in a "hands-free" way:

```
POST /projects/:id/runners/:runner_id
DELETE /projects/:id/runners/:runner_id
```

Thanks again and looking forward to your thoughts.

@randx @dosire
