### PR TITLE
expose project name

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -25,7 +25,7 @@ class Build < ActiveRecord::Base
   serialize :push_data
 
   attr_accessible :project_id, :ref, :sha, :before_sha,
-    :status, :finished_at, :trace, :started_at, :push_data, :runner_id
+    :status, :finished_at, :trace, :started_at, :push_data, :runner_id, :project_name
 
   validates :sha, presence: true
   validates :ref, presence: true
@@ -156,5 +156,9 @@ class Build < ActiveRecord::Base
 
   def allow_git_fetch
     project.allow_git_fetch
+  end
+
+  def project_name
+    project.name
   end
 end

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -1,7 +1,7 @@
 module API
   module Entities
     class Build < Grape::Entity
-      expose :id, :commands, :path, :ref, :sha, :project_id, :repo_url, :before_sha, :timeout, :allow_git_fetch
+      expose :id, :commands, :path, :ref, :sha, :project_id, :repo_url, :before_sha, :timeout, :allow_git_fetch, :project_name
     end
 
     class Runner < Grape::Entity


### PR DESCRIPTION
It would be nice to have access to the project name over on the runner side. This change exposes the project name.

Same as https://github.com/gitlabhq/gitlab-ci/pull/301 only now mergeable.
