### PR TITLE
Fix for error in gitlab_ci init script

### DIFF
--- a/lib/support/init.d/gitlab_ci
+++ b/lib/support/init.d/gitlab_ci
@@ -48,7 +48,7 @@ start() {
   else
     if [ `whoami` = root ]; then
       ! [ -e $SOCKET_FILE ] || sudo -u $APP_USER -H bash -l -c  "rm $SOCKET_FILE"
-      sudo -u $APP_USER -H bash -l -c "RAILS_ENV=production bundle exec puma $DAEMON_OPTS"
+      sudo -u $APP_USER -H bash -l -c "RAILS_ENV=production bundle exec \"puma $DAEMON_OPTS\""
       sudo -u $APP_USER -H bash -l -c "mkdir -p $PID_PATH && $START_SIDEKIQ  > /dev/null  2>&1 &"
       echo "$DESC started"
     fi


### PR DESCRIPTION
Hi,
I followed this great installation instruction:

https://github.com/gitlabhq/gitlab-ci/blob/master/doc/installation.md

and I noticed that there is bug in gitlab_ci init script. It wasn't able to start the GitLab CI service, because options and parameters of `puma` were interpreted as options and parameters of `bundle exec`. This pull request fixes this bug.

Jiri
