### PR TITLE
keep Gem using bt2.3 insteadof bt3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       descendants_tracker (~> 0.0.1)
       ice_nine (~> 0.9)
     backports (3.3.5)
-    bootstrap-sass (3.0.2.1)
+    bootstrap-sass (2.3.2.2)
       sass (~> 3.2)
     builder (3.0.4)
     capybara (2.1.0)


### PR DESCRIPTION
change gemfile.lock to keep use bootstrap2.3 series
(or it will outof styling)
