### PR TITLE
allow runners to submit large build logs

### DIFF
--- a/lib/support/nginx/gitlab_ci
+++ b/lib/support/nginx/gitlab_ci
@@ -29,4 +29,8 @@ server {
 
     proxy_pass http://gitlab_ci;
   }
+
+  # adjust this to match the largest build log your runners might submit,
+  # set to 0 to disable limit
+  client_max_body_size 10m;
 }


### PR DESCRIPTION
The default nginx configuration will only allow for 1 megabyte request bodies, so large build logs from runners will be rejected by the server.

This patch sets the limit to 10 megabytes. I'm not sure what a sensible default might be, but 1m seem a bit over-conservative to me.
