### PR TITLE
Set #project_scripts to use a monospace font

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -340,3 +340,7 @@ h3 {
     left: 4px;
   }
 }
+
+#project_scripts {
+  font-family: monospace;
+}


### PR DESCRIPTION
Since unit test scripts are currently defined in a textarea. This will improve legibility.
