### PR TITLE
Remove last bar in url.

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -6,12 +6,12 @@ sending the `private-token` of a valid user and the `url` of an
 authorized Gitlab instance via a query string along with the API
 request:
 
-    GET http://ci.example.com/api/v1/projects?private_token=QVy1PB7sTxfy4pqfZM1U&url=http://demo.gitlab.com/
+    GET http://ci.example.com/api/v1/projects?private_token=QVy1PB7sTxfy4pqfZM1U&url=http://demo.gitlab.com
 
 If preferred, you may instead send the `private-token` as a header in
 your request:
 
-    curl --header "PRIVATE-TOKEN: QVy1PB7sTxfy4pqfZM1U" "http://ci.example.com/api/v1/projects?url=http://demo.gitlab.com/"
+    curl --header "PRIVATE-TOKEN: QVy1PB7sTxfy4pqfZM1U" "http://ci.example.com/api/v1/projects?url=http://demo.gitlab.com"
 
 All API requests are serialized using JSON.  You don't need to specify
 `.json` at the end of API URL.


### PR DESCRIPTION
With the last bar in the url I am getting a 403.

curl -X GET 'http://33.33.33.11:9292/api/v1/projects?private_token=xD6uHWzudpJVEhrjUjRo&url=http://33.33.33.10/'
{"message":"403 Forbidden"}

curl -X GET 'http://33.33.33.11:9292/api/v1/projects?private_token=xD6uHWzudpJVEhrjUjRo&url=http://33.33.33.10'
[]
