### PR TITLE
Fix issue #302

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 20140130121538) do
     t.string   "ref"
     t.string   "status"
     t.datetime "finished_at"
-    t.text     "trace",       limit: 2147483647
+    t.text     "trace",       limit: 1073741823
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "sha"


### PR DESCRIPTION
The max text size is 1GB in postgresql, so gitlab-ci will failed when create database in postgresql.

```
1073741823 = 1GB - 1
```
