### PR TITLE
Add missing verb to failed build email

### DIFF
--- a/app/views/layouts/notify.html.haml
+++ b/app/views/layouts/notify.html.haml
@@ -22,4 +22,4 @@
         %td{align: "left", style: "margin: 0; padding: 10px;"}
           %p{style: "font-size:small;color:#777"}
             - if @project
-              You're receiving this notification because you the one who triggered a build on the #{@project.name} project.
+              You're receiving this notification because you are the one who triggered a build on the #{@project.name} project.


### PR DESCRIPTION
Failed build triggers an email with a sentence missing a verb. I'm not sure whether `You're` should be changed to `You are` as well, any preference?
