### PR TITLE
Runner description editing improvements

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -21,10 +21,21 @@
 #
 #
 
-$(document).on 'click', '.edit-runner-link', ->
+$(document).on 'click', '.edit-runner-link', (event) ->
+  event.preventDefault()
+
   descr = $(this).closest('.runner-description').first()
   descr.hide()
-  descr.next('.runner-description-form').show()
+  form = descr.next('.runner-description-form')
+  descrInput = form.find('input.description')
+  originalValue = descrInput.val()
+  form.show()
+  form.find('.cancel').on 'click', (event) ->
+    event.preventDefault()
+
+    form.hide()
+    descrInput.val(originalValue)
+    descr.show()
 
 $(document).on 'click', '.assign-all-runner', ->
   $(this).replaceWith('<i class="icon-refresh icon-spin"></i> Assign in progress..')

--- a/app/views/admin/runners/_runner.html.haml
+++ b/app/views/admin/runners/_runner.html.haml
@@ -19,6 +19,7 @@
         .form-group
           = f.text_field :description, class: 'form-control'
         = f.submit 'Save', class: 'btn'
+        %span (#{link_to 'cancel', '#', class: 'cancel'})
   %td
     - if runner.shared?
       \-


### PR DESCRIPTION
Hi folks.

Here's a few improvements you may be interesting:
1) There was a bug when clicking "edit" on runner row: because of lack of preventDefault page was reloading
2) I added couple of styles to make "save" button look nicer
3) I added "cancel" button to cancel description editing

![screen shot 2014-03-21 at 10 14 47 pm](https://f.cloud.github.com/assets/39785/2486912/3630ab66-b12d-11e3-9275-ea064d932be8.png)
