### PR TITLE
Fix "Assign to all" when runner already assigned to some projects

### DIFF
--- a/app/controllers/admin/runners_controller.rb
+++ b/app/controllers/admin/runners_controller.rb
@@ -29,7 +29,7 @@ class Admin::RunnersController < Admin::ApplicationController
   end
 
   def assign_all
-    Project.all.each { |project| @runner.assign_to(project, current_user) }
+    Project.unassigned(@runner).all.each { |project| @runner.assign_to(project, current_user) }
 
     respond_to do |format|
       format.js

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -90,6 +90,12 @@ ls -la
     def already_added?(project)
       where(gitlab_url: project.web_url).any?
     end
+
+    def unassigned(runner)
+      joins('LEFT JOIN runner_projects ON runner_projects.project_id = projects.id ' \
+        "AND runner_projects.runner_id = #{runner.id}").
+      where('runner_projects.project_id' => nil)
+    end
   end
 
   def set_default_values


### PR DESCRIPTION
This commit fixes issue #333 + small performance improvement: "Assign to all" action queries assigns only for unassigned projects.
