### PR TITLE
Ignore config/unicorn.rb.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config/application.yml
 config/database.yml
 config/puma.rb
 config/resque.yml
+config/unicorn.rb
 coverage/*
 log/*
 tmp/*


### PR DESCRIPTION
The file is created on the installation procedure at `sudo -u gitlab_ci -H editor config/unicorn.rb` and is installation dependent.
