### PR TITLE
Remove config/puma.rb from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 ci.db
 config/application.yml
 config/database.yml
-config/puma.rb
 config/resque.yml
 coverage/*
 log/*


### PR DESCRIPTION
`git grep` tells me this is the last occurence of puma outside the CHANGELOG.
