### PR TITLE
Relative urls for build path

### DIFF
--- a/app/helpers/builds_helper.rb
+++ b/app/helpers/builds_helper.rb
@@ -26,6 +26,6 @@ module BuildsHelper
   end
 
   def build_url(build)
-    project_build_url(build.project, build)
+    project_build_path(build.project, build)
   end
 end


### PR DESCRIPTION
In the project view urls to the builds use a hardcode url instead of a relative url. In my installation this would cause the link to be set to 10.0.0.5:9292/project/:projectid/builds/:buildid

With the change to the link generator the paths are now relative so it always points to the correct location.

This problem also occurs, and is also fixed, in build view if there are other builds for the same commit.