### PR TITLE
Add application.yml.example.development.

### DIFF
--- a/config/application.yml.example.development
+++ b/config/application.yml.example.development
@@ -1,0 +1,7 @@
+development:
+  allowed_gitlab_urls:
+    - 'http://localhost:3000'
+  gitlab_ci:
+    host: localhost
+    port: 5000
+    https: false

--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -109,8 +109,11 @@ You can use either MySQL or PostgreSQL.
 ## 6. Setup application
 
     # Edit application settings
+    # Production
     sudo -u gitlab_ci -H cp config/application.yml.example config/application.yml
     sudo -u gitlab_ci -H editor config/application.yml
+    # Development
+    #sudo -u gitlab_ci -H cp config/application.yml.example.development config/application.yml
 
     # Edit web server settings
     sudo -u gitlab_ci -H cp config/unicorn.rb.example config/unicorn.rb


### PR DESCRIPTION
Same rationale as: https://github.com/gitlabhq/gitlabhq/blob/master/config/unicorn.rb.example.development but even more needed here because we have no recipe.

I have configured it two times,, and I wasted 1 hour each to figure out my error because I was not using the `http://` before `localhost`.
