### PR TITLE
Remove -y on dependencies

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -28,7 +28,7 @@ the default editor.
 
 Install the required packages:
 
-    sudo apt-get install -y wget curl gcc checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libreadline6-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev openssh-server git-core libyaml-dev postfix libpq-dev libicu-dev
+    sudo apt-get install wget curl gcc checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libreadline6-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev openssh-server git-core libyaml-dev postfix libpq-dev libicu-dev
     sudo apt-get install redis-server 
 
 # 2. Ruby


### PR DESCRIPTION
It almost uninstalled ssmtp. It's not safe to just paste the command with the `-y` switch when packages like postfix are involved
