### PR TITLE
Remove -y on dependencies

### DIFF
--- a/doc/install/installation.md
+++ b/doc/install/installation.md
@@ -23,12 +23,12 @@ below. If you are not familiar with vim please skip this and keep using
 the default editor.
 
     # Install vim
-    sudo apt-get install -y vim
+    sudo apt-get install vim
     sudo update-alternatives --set editor /usr/bin/vim.basic
 
 Install the required packages:
 
-    sudo apt-get install -y wget curl gcc checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libreadline6-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev openssh-server git-core libyaml-dev postfix libpq-dev libicu-dev
+    sudo apt-get install wget curl gcc checkinstall libxml2-dev libxslt-dev libcurl4-openssl-dev libreadline6-dev libc6-dev libssl-dev libmysql++-dev make build-essential zlib1g-dev openssh-server git-core libyaml-dev postfix libpq-dev libicu-dev
     sudo apt-get install redis-server 
 
 # 2. Ruby
@@ -59,7 +59,7 @@ You can use either MySQL or PostgreSQL.
 ### MySQL
 
     # Install the database packages
-    sudo apt-get install -y mysql-server mysql-client libmysqlclient-dev
+    sudo apt-get install mysql-server mysql-client libmysqlclient-dev
 
     # Login to MySQL
     $ mysql -u root -p


### PR DESCRIPTION
Otherwise blindly pasting them might have unintended side-effects, like uninstalling alternatives to postfix.

For me the dependency command  almost uninstalled ssmtp. It's not safe to just paste the command with the `-y` switch when packages like postfix are involved
