### PR TITLE
Hide projects that have been archived in Gitlab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v5.0.2
+  - Hide projects that have already been archived in Gitlab
+
 v5.0.1
   - Update rails to 4.0.5
 

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -52,7 +52,7 @@ class Network
     response = self.class.get(endpoint, opts)
 
     if response.code == 200
-      response.parsed_response
+      response.parsed_response.delete_if { |p| p['archived'] == true }    
     else
       nil
     end


### PR DESCRIPTION
As it does not make sense to show unconfigured projects that have already been archived, I filtered them after making the API call to Gitlab. If you think that there are situations where it may somehow be useful (I couldn't come up with one), I'll make this configurable via `application.yml`.
Also, I couldn't find any specs for either the `Network` class or the `Project::from_gitlab` method, so I didn't adapt any tests.
