### PR TITLE
fix gitlab-ci init.d script for debian

### DIFF
--- a/lib/support/init.d/gitlab_ci
+++ b/lib/support/init.d/gitlab_ci
@@ -39,7 +39,7 @@ test -f /etc/default/gitlab-ci && . /etc/default/gitlab-ci
 
 # Switch to the app_user if it is not he/she who is running the script.
 if [ "$USER" != "$app_user" ]; then
-  sudo -u "$app_user" -H -i $0 "$@"; exit;
+  su "$app_user" -l -c "$0 $@"; exit;
 fi
 
 # Switch to the gitlab path, exit on failure.


### PR DESCRIPTION
This commit addresses an issue with the gitlab-ci init.d script on Debian based systems.
This script makes use of `sudo` which raise two problems on Debian:
1. by default `sudo` is not installed on Debian,
2. even if `sudo` is installed, `root` is not a sudoer by default on Debian

As a result `service gitlab_ci start` or `service gitlab_ci stop` fails throwing the following error: `root is not in the sudoers file.  This incident will be reported.`.

This commit replaces the following:

```
# Switch to the app_user if it is not he/she who is running the script.
if [ "$USER" != "$app_user" ]; then
  sudo -u "$app_user" -H -i $0 "$@"; exit;
fi
```

by

```
# Switch to the app_user if it is not he/she who is running the script.
if [ "$USER" != "$app_user" ]; then
  su "$app_user" -l -c "$0 $@"; exit;
fi
```

Signed-off-by: Remi BARRAQUAND dev@remibarraquand.com
Signed-off-by: Charles EYNARD charles.eynard@yeastlab.fr
