### PR TITLE
Add pagination to project API

### DIFF
--- a/lib/api/projects.rb
+++ b/lib/api/projects.rb
@@ -9,7 +9,9 @@ module API
       # Example Request:
       #   GET /projects
       get do
-        gitlab_projects = Project.from_gitlab(current_user, nil, nil, :authorized)
+        gitlab_projects = Project.from_gitlab(
+          current_user, params[:page], params[:per_page], :authorized
+        )
         ids = gitlab_projects.map { |project| project.id }
 
         projects = Project.where("gitlab_id IN (?)", ids).load
@@ -21,7 +23,9 @@ module API
       # Example Request:
       #   GET /projects/owned
       get "owned" do
-        gitlab_projects = Project.from_gitlab(current_user, nil, nil, :owned)
+        gitlab_projects = Project.from_gitlab(
+          current_user, params[:page], params[:per_page], :owned
+        )
         ids = gitlab_projects.map { |project| project.id }
 
         projects = Project.where("gitlab_id IN (?)", ids).load


### PR DESCRIPTION
The project API used `nil` as `page` and `per_page` parameters. So there was no way to get all project with API if there was more than 100 projects.

This MR fixes this by adding `params[:page]` and `params[:per_page]` to the `Project.from_gitlab` call. The parameters are still optional (if there are undefined, it just send `nil`).

It affects the API routes:
`GET /projects`
`GET /projects/owned`
