### PR TITLE
Call POST /api/v1/build/:project_id/rebuild to rerun the last build.

### DIFF
--- a/lib/api/builds.rb
+++ b/lib/api/builds.rb
@@ -89,6 +89,23 @@ module API
           render_api_error!(errors, 400)
         end
       end
+
+      # Create a new build the same as previous one if no pending is found
+      #
+      # Parameters:
+      #   id (required) - The ID of a project
+      # Example Request:
+      #   POST /builds/:project_id/rebuild
+      post ":project_id/rebuild" do
+        build = Build.where(project_id: params[:project_id]).last
+        if build.pending?
+            render_api_error!("Build with id '#{build.id}' is already pending.", 200)
+        else
+            Build.create_from(build)
+            render_api_error!("Build has been added", 200)
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
For our product we have ~15 repositories small repositories (composer components) and 2 project repositories. When we commit to any them, we need the main repositories to start building. Code from other repositories is then downloaded via composer update.

This patch allows us to add web hook to every project, therefore we are able to rebuild our app everytime something get changed.

PS: Security needs to be improved, because everybody can add builds, howeverthis is first time, I changed something in ruby and I don't understand it much. Hope, you will understand the idea and reimplement it better.