### PR TITLE
Add fail_timeout option to nginx vhost

### DIFF
--- a/lib/support/nginx/gitlab_ci
+++ b/lib/support/nginx/gitlab_ci
@@ -3,7 +3,7 @@
 # App Version: 2.0
 
 upstream gitlab_ci {
-  server unix:/home/gitlab_ci/gitlab-ci/tmp/sockets/gitlab-ci.socket;
+  server unix:/home/gitlab_ci/gitlab-ci/tmp/sockets/gitlab-ci.socket fail_timeout=0;
 }
 
 server {


### PR DESCRIPTION
Add fail_timeout option to upstream to allow quick retry

Signed-off-by: Boris HUISGEN <bhuisgen@hbis.fr>