### PR TITLE
Make autoscroll button floatable within build trace window

### DIFF
--- a/app/assets/javascripts/build.coffee
+++ b/app/assets/javascripts/build.coffee
@@ -4,7 +4,7 @@ class Build
   constructor: (build_url, build_status) ->
     clearInterval(Build.interval)
 
-    if build_status == "running" || build_status == "pending"
+    if build_status == "running"
       #
       # Bind autoscroll button to follow build output
       #
@@ -18,6 +18,20 @@ class Build
           $(this).text "disable autoscroll"
 
       #
+      # Position autoscroll button with window scroll
+      #
+      $(window).on 'scroll':->
+        basePadding = 5
+        padding = 10
+        currentScroll = $(window).scrollTop()
+        top = $(".bash").offset().top
+        if currentScroll > top - padding
+          $("#autoscroll-container").stop().animate({top: currentScroll - top + padding + basePadding}, 200)
+        else
+          $("#autoscroll-container").stop().animate({top: basePadding}, 200)
+
+    if build_status == "running" || build_status == "pending"
+      #
       # Check for new build output if user still watching build page
       # Only valid for runnig build when output changes during time
       #
@@ -27,12 +41,12 @@ class Build
             url: build_url
             dataType: "json"
             success: (build) =>
-              if build.status == "running"
+              if build.status != build_status
+                Turbolinks.visit build_url
+              else if build.status == "running"
                 $('#build-trace code').html build.trace_html
                 $('#build-trace code').append '<i class="icon-refresh icon-spin"/>'
                 @checkAutoscroll()
-              else
-                Turbolinks.visit build_url
       , 4000
 
   checkAutoscroll: ->

--- a/app/assets/stylesheets/sections/builds.scss
+++ b/app/assets/stylesheets/sections/builds.scss
@@ -8,8 +8,8 @@ pre.trace {
   white-space: -pre-wrap;      /* Opera 4-6 */
   white-space: -o-pre-wrap;    /* Opera 7 */
   word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  position: relative;
   overflow: auto;
-  overflow-y: hidden;
   font-size: 12px;
 
   .icon-refresh {
@@ -19,10 +19,17 @@ pre.trace {
 }
 
 .autoscroll-container {
-  position: fixed;
+  position: absolute;
   bottom: 10px;
-  right: 20px;
+  right: 15px;
+  margin-bottom: 5px;
+  top: 5px;
   z-index: 100;
+
+  h4 {
+    line-height: 0px;
+    margin: 0px;
+  }
 }
 
 .build-widget {

--- a/app/views/builds/show.html.haml
+++ b/app/views/builds/show.html.haml
@@ -56,12 +56,12 @@
 
 
 
-    .clearfix
-      - if @build.active?
-        .autoscroll-container
-          %button.btn.btn-success.btn-sm#autoscroll-button{:type => "button", :data => {:state => 'disabled'}} enable autoscroll
-        .clearfix
     %pre.trace#build-trace
+      - if @build.running?
+        .autoscroll-container#autoscroll-container
+          %h4
+            %button.btn.btn-success.btn-sm#autoscroll-button{:type => "button", :data => {:state => 'disabled'}} enable autoscroll
+
       %code.bash
         = preserve do
           = raw @build.trace_html


### PR DESCRIPTION
- Autoscroll button flows with browser scroll
- Autoscroll button is shown only for currently running builds
- Refresh browser window when status changes

Maybe CSS can made by simpler. I'm also thinking about `Jenkins` approach when window is automatically scrolled when you are at end of build log. @randx what do you think?
