### PR TITLE
Added incremental build output

### DIFF
--- a/app/assets/javascripts/build.coffee
+++ b/app/assets/javascripts/build.coffee
@@ -1,7 +1,8 @@
 class Build
   @interval: null
+  @state: null
 
-  constructor: (build_url, build_status) ->
+  constructor: (build_url, build_status, build_state) ->
     clearInterval(Build.interval)
 
     if build_status == "running" || build_status == "pending"
@@ -21,15 +22,21 @@ class Build
       # Check for new build output if user still watching build page
       # Only valid for runnig build when output changes during time
       #
+      @state = build_state
+
       Build.interval = setInterval =>
         if window.location.href is build_url
           $.ajax
-            url: build_url
+            url: build_url + "/log.json?state=" + encodeURIComponent(JSON.stringify(@state))
             dataType: "json"
             success: (build) =>
               if build.status == "running"
-                $('#build-trace code').html build.trace_html
-                $('#build-trace code').append '<i class="icon-refresh icon-spin"/>'
+                @state = build.state
+                if build.state.append
+                  $('.icon-refresh').before build.html
+                else
+                  $('#build-trace code').html build.html
+                  $('#build-trace code').append '<i class="icon-refresh icon-spin"/>'
                 @checkAutoscroll()
               else
                 Turbolinks.visit build_url

--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -46,6 +46,26 @@ class BuildsController < ApplicationController
     render json: @build.to_json(only: [:status, :id, :sha, :coverage])
   end
 
+  def log
+    respond_to do |format|
+      format.text {
+        render text: @build.trace
+      }
+      format.json {
+        state = nil
+        begin
+          state = JSON.parse(params[:state], symbolize_names: true)
+        rescue
+        end
+
+        trace = @build.trace_for_state(state)
+        trace.merge!(id: @build.id, status: @build.status)
+
+        render json: trace
+      }
+    end
+  end
+
   def cancel
     @build.cancel
 

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -125,8 +125,18 @@ class Build < ActiveRecord::Base
     to: :commit, prefix: false
 
   def trace_html
-    html = Ansi2html::convert(trace) if trace.present?
-    html ||= ''
+    html = Ansi2html::convert(trace)[:html] if trace.present?
+    html ||= ""
+  end
+
+  def trace_state
+    state = Ansi2html::convert(trace)[:state] if trace.present?
+    state ||= ""
+  end
+
+  def trace_for_state(state = nil)
+    out = Ansi2html::convert(trace, state) if trace.present?
+    out ||= {}
   end
 
   def started?

--- a/app/views/builds/show.html.haml
+++ b/app/views/builds/show.html.haml
@@ -65,6 +65,8 @@
       %code.bash
         = preserve do
           = raw @build.trace_html
+          - if @build.active?
+            %i{:class => "icon-refresh icon-spin"}
 
   .col-md-3
     - if @build.coverage
@@ -137,4 +139,4 @@
 
 
 :javascript
-  new Build("#{build_url(@build)}", "#{@build.status}")
+  new Build("#{build_url(@build)}", "#{@build.status}", #{@build.trace_state.to_json})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ GitlabCi::Application.routes.draw do
       member do
         get :cancel
         get :status
+        get :log
         post :retry
       end
     end


### PR DESCRIPTION
- We pass converter state to client side
- Client side when next time requests build output sends last received converter state
- Converter state is restored and generation is resumed from that place
- All span's are properly restored
- Currently there is simple check if build changed: offset present in state is within currently saved build output. This can be enhanced to introduce some simple checksum: CRC16 or CRC32 should be sufficient.

It's made to greatly reduce network traffic and increase performance of html generation.

THIS IS PROOF OF CONCEPT HOW IT CAN BE DONE