### PR TITLE
Fix Integration page header of required GitLab version

### DIFF
--- a/app/views/projects/integration.html.haml
+++ b/app/views/projects/integration.html.haml
@@ -1,5 +1,5 @@
 %h3
-  Integration with GitLab. Requires GitLab 6.3+
+  Integration with GitLab. Requires GitLab 7.5+
 %hr
 %form.form-horizontal
   .bs-callout.bs-callout-info


### PR DESCRIPTION
GitLab CI 5.2 requires GitLab 7.5, fix the Integration tab header to reflect that.
