### PR TITLE
Undefined method last_build for running schedule_builds

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,6 +38,7 @@ class Project < ActiveRecord::Base
   has_many :runners, through: :runner_projects
   has_many :web_hooks, dependent: :destroy
   has_many :jobs, dependent: :destroy
+  has_one :last_build, ->() { order('id DESC') }, class_name: 'Build'
 
   accepts_nested_attributes_for :jobs, allow_destroy: true
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -38,7 +38,6 @@ class Project < ActiveRecord::Base
   has_many :runners, through: :runner_projects
   has_many :web_hooks, dependent: :destroy
   has_many :jobs, dependent: :destroy
-  has_one :last_build, ->() { order('id DESC') }, class_name: 'Build'
 
   accepts_nested_attributes_for :jobs, allow_destroy: true
 
@@ -111,6 +110,10 @@ ls -la
 
   def set_default_values
     self.token = SecureRandom.hex(15) if self.token.blank?
+  end
+  
+  def last_build
+    builds.last
   end
 
   def gitlab?


### PR DESCRIPTION
I did a fresh installation of Gitlab-CI 5-2-stable on Ubuntu 14.04 Server. The whenever cronjob for scheduled builds always failed with to error message stated below.

```bash
gitlab_ci@st00166:~/gitlab-ci$ RAILS_ENV=production bundle exec rake schedule_builds --trace
** Invoke schedule_builds (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute schedule_builds
rake aborted!
NoMethodError: undefined method `last_build' for #<Project:0x007ff8a47eefb0>
...
```

This is because the last_build only exists as method in Runner model.

The missing method error exists in 5-2-stable and master.