### PR TITLE
associated builds for commit should be destroyed as dependent

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,7 +1,7 @@
 class ProjectsController < ApplicationController
   before_filter :authenticate_user!, except: [:build, :badge, :index, :show]
-  before_filter :project, only: [:build, :integration, :show, :badge, :edit, :update, :destroy]
-  before_filter :authorize_access_project!, except: [:build, :gitlab, :badge, :index, :show, :new, :create]
+  before_filter :project, only: [:summary, :build, :integration, :show, :badge, :edit, :update, :destroy]
+  before_filter :authorize_access_project!, except: [:summary, :build, :gitlab, :badge, :index, :show, :new, :create]
   before_filter :authenticate_token!, only: [:build]
   before_filter :no_cache, only: [:badge]
   protect_from_forgery except: :build
@@ -40,6 +40,9 @@ class ProjectsController < ApplicationController
     @commits = @project.commits
     @commits = @commits.where(ref: @ref) if @ref
     @commits = @commits.order('id DESC').page(params[:page]).per(20)
+  end
+
+  def summary
   end
 
   def integration

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -70,7 +70,7 @@ class Build < ActiveRecord::Base
       commit_id: build.commit_id,
       job_id: build.job_id,
       status: :pending,
-      commands: build.commands
+      commands: build.job.commands
     )
   end
 

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -14,7 +14,7 @@
 
 class Commit < ActiveRecord::Base
   belongs_to :project
-  has_many :builds
+  has_many :builds, :dependent=>:destroy
   has_many :jobs, through: :builds
 
   serialize :push_data

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -14,7 +14,7 @@
 
 class Commit < ActiveRecord::Base
   belongs_to :project
-  has_many :builds, :dependent=>:destroy
+  has_many :builds, dependent: :destroy
   has_many :jobs, through: :builds
 
   serialize :push_data

--- a/app/views/admin/projects/_project.html.haml
+++ b/app/views/admin/projects/_project.html.haml
@@ -3,7 +3,7 @@
   %td
     = project.id
   %td
-    = link_to [:admin, project] do
+    = link_to [project] do
       %strong= project.name
   %td
     - if last_commit

--- a/app/views/layouts/project.html.haml
+++ b/app/views/layouts/project.html.haml
@@ -42,5 +42,9 @@
                 = link_to edit_project_path(@project) do
                   %i.icon-edit
                   Settings
+              = nav_link path: 'projects#summary' do
+                = link_to summary_project_path(@project) do
+                  %i.icon-info-sign
+                  Summary
         .col-md-10
           = yield

--- a/app/views/projects/summary.html.haml
+++ b/app/views/projects/summary.html.haml
@@ -1,0 +1,81 @@
+%h4.page-title
+  Project: #{@project.name}
+
+%p
+  = link_to admin_projects_path do
+    &larr; Back to projects list
+%hr
+.row
+  .col-md-6
+    %fieldset
+      %legend Project info
+      %p
+        ID:
+        %strong= @project.id
+      %p
+        Name:
+        %strong= @project.name
+      %p
+        Build timeout:
+        %strong= @project.timeout
+      %p
+        GitLab ID:
+        %strong= @project.gitlab_id
+      %p
+        Created at:
+        %strong= @project.created_at
+      %p
+        Token:
+        %strong= @project.token
+      %p
+        Public:
+        %strong= @project.public
+      %p
+        Last build:
+        - if @project.last_commit_date
+          = time_ago_in_words @project.last_commit_date
+    %br
+    %fieldset
+      %legend Email notification
+      %p
+        Repicients:
+        %strong= @project.email_recipients
+      %p
+        Send mail to commiter:
+        %strong= @project.email_add_committer
+      %p
+        Send on all broken builds:
+        %strong= @project.email_only_broken_builds
+
+  .col-md-6
+    - @project.jobs.active.each do |job|
+      %fieldset
+        %legend 
+          Build script for #{job.name}
+        = preserve do
+          %pre
+            = job.commands
+
+    %br
+    %fieldset
+      %legend Builds stats
+      %p
+        Total:
+        %strong= pluralize @project.builds.count, 'build'
+      %p
+        Successful:
+        %strong= pluralize @project.builds.success.count, 'build'
+      %p
+        Failed:
+        %strong= pluralize @project.builds.failed.count, 'build'
+
+      %p
+        Success ratio:
+        %strong
+          #{success_ratio(@project.builds.success, @project.builds.failed)}%
+
+      %p
+        Commits covered:
+        %strong
+          = @project.commits.count
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ GitlabCi::Application.routes.draw do
     member do
       get :status, to: 'projects#badge'
       get :integration
+      get :summary
       post :build
     end
 


### PR DESCRIPTION
Fixes this issue:  https://github.com/gitlabhq/gitlab-ci/issues/511

and

https://github.com/gitlabhq/gitlab-ci/issues/507

Retry builds should use the latest job build commands.

