### PR TITLE
Corrected API documentation link

### DIFF
--- a/app/views/helps/show.html.haml
+++ b/app/views/helps/show.html.haml
@@ -13,7 +13,7 @@
 
 .bs-callout.bs-callout-success
   %h4
-    = link_to 'https://gitlab.com/gitlab-org/gitlab-ci/blob/master/doc/api/api.md' do
+    = link_to 'https://gitlab.com/gitlab-org/gitlab-ci/blob/master/doc/api' do
       %i.icon-cogs
       API
   %p Explore how you can access GitLab CI via the API.


### PR DESCRIPTION
The API documentation link currently leads of a 404 page. This commit corrects the link. 
