### PR TITLE
Upgrade raindrops gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,7 +217,7 @@ GEM
       activesupport (= 4.0.10)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    raindrops (0.12.0)
+    raindrops (0.13.0)
     rake (10.3.2)
     rb-fsevent (0.9.3)
     rb-inotify (0.9.2)


### PR DESCRIPTION
On Ubuntu Trusty `raindrops` version 0.12.0 fails to install (see below). Updating to 0.13.0 seems to work fine.
```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ gem install raindrops -v '0.12.0'
Building native extensions.  This could take a while...
ERROR:  Error installing raindrops:
	ERROR: Failed to build gem native extension.

    /home/vagrant/.rvm/rubies/ruby-2.2.0/bin/ruby -r ./siteconf20150129-19549-i6h5yi.rb extconf.rb
checking for mmap() in sys/mman.h... yes
checking for munmap() in sys/mman.h... yes
checking for mremap() in sys/mman.h... yes
checking for getpagesize() in unistd.h... yes
checking for rb_thread_blocking_region()... no
checking for rb_thread_io_blocking_region()... yes
checking for GCC 4+ atomic builtins... yes
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling linux_inet_diag.c
In file included from linux_inet_diag.c:17:0:
/home/vagrant/.rvm/rubies/ruby-2.2.0/include/ruby-2.2.0/ruby/backward/rubysig.h:14:2: warning: #warning rubysig.h is obsolete [-Wcpp]
 #warning rubysig.h is obsolete
  ^
linux_inet_diag.c: In function ‘rb_thread_blocking_region’:
linux_inet_diag.c:28:2: error: ‘TRAP_BEG’ undeclared (first use in this function)

▽
  TRAP_BEG;
  ^
linux_inet_diag.c:28:2: note: each undeclared identifier is reported only once for each function it appears in
linux_inet_diag.c:30:2: error: ‘TRAP_END’ undeclared (first use in this function)
  TRAP_END;

▽
GEM
  remote: https://rubygems.org/
  specs:
    actionmailer (4.0.10)
      actionpack (= 4.0.10)
      mail (~> 2.5, >= 2.5.4)
    actionpack (4.0.10)
      activesupport (= 4.0.10)
      builder (~> 3.1.0)
      erubis (~> 2.7.0)
      rack (~> 1.5.2)
      rack-test (~> 0.6.2)
    activemodel (4.0.10)
      activesupport (= 4.0.10)
      builder (~> 3.1.0)
    activerecord (4.0.10)
      activemodel (= 4.0.10)
      activerecord-deprecated_finders (~> 1.0.2)
      activesupport (= 4.0.10)
      arel (~> 4.0.0)
    activerecord-deprecated_finders (1.0.3)
    activerecord-session_store (0.1.0)
      actionpack (>= 4.0.0, < 5)
      activerecord (>= 4.0.0, < 5)
      railties (>= 4.0.0, < 5)
/rain
      actionmailer (= 4.0.10)
  ^
linux_inet_diag.c: At top level:
linux_inet_diag.c:22:1: warning: ‘rb_thread_blocking_region’ defined but not used [-Wunused-function]
 rb_thread_blocking_region(
 ^
make: *** [linux_inet_diag.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/vagrant/.rvm/gems/ruby-2.2.0/gems/raindrops-0.12.0 for inspection.
Results logged to /home/vagrant/.rvm/gems/ruby-2.2.0/extensions/x86_64-linux/2.2.0/raindrops-0.12.0/gem_make.out
```