### PR TITLE
Add test coverage parsing example for pytest-cov

### DIFF
--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -74,6 +74,9 @@
             %li
               Simplecov (Ruby) -
               %code \(\d+.\d+\%\) covered
+            %li
+              pytest-cov (Python) -
+              %code \d+\%$
 
 
 


### PR DESCRIPTION
Add the regex code needed to parse coverage results from [pytest-cov](https://pypi.python.org/pypi/pytest-cov).