### PR TITLE
Fixed typo in gitlab ci api documentation

### DIFF
--- a/doc/api/projects.md
+++ b/doc/api/projects.md
@@ -91,7 +91,7 @@ Parameters:
 
 Creates a Gitlab CI project using Gitlab project details.
 
-    POST /projects/:id
+    POST /projects
 
 Parameters:
 


### PR DESCRIPTION
project create does not take an id as a parameter