### PR TITLE
Redirect to root path when application.yml config is valid

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,13 +71,19 @@ class ApplicationController < ActionController::Base
   end
 
   def check_config
+    redirect_to oauth2_help_path unless valid_config?
+  end
+
+  def valid_config?
     server = GitlabCi.config.gitlab_server
 
     if server.blank? || server.url.blank? || server.app_id.blank? || server.app_secret.blank?
-      redirect_to oauth2_help_path
+      false
+    else
+      true
     end
   rescue Settingslogic::MissingSetting, NoMethodError
-    redirect_to oauth2_help_path
+    false
   end
 
   def invalid_token

--- a/app/controllers/helps_controller.rb
+++ b/app/controllers/helps_controller.rb
@@ -5,6 +5,10 @@ class HelpsController < ApplicationController
   end
 
   def oauth2
-    render layout: "empty"
+    if valid_config?
+      redirect_to root_path
+    else
+      render layout: 'empty'
+    end
   end
 end

--- a/app/views/helps/oauth2.html.haml
+++ b/app/views/helps/oauth2.html.haml
@@ -12,5 +12,9 @@
       %code= callback_user_sessions_url
     %li
       Update the GitLab CI config with the application id and the application secret from GitLab.
+    %li
+      Restart your GitLab CI instance
+    %li
+      Refresh this page when GitLab CI has started again
 
 


### PR DESCRIPTION
**What does this PR do?**
When you first start Gitlab CI you get the help/oauth2 page. After you have finished all the steps and you refresh the page nothing seems to happen. With this PR I want to help people get to their next step.