### PR TITLE
Only update trace when trace is given

### DIFF
--- a/lib/api/builds.rb
+++ b/lib/api/builds.rb
@@ -32,7 +32,7 @@ module API
       put ":id" do
         authenticate_runner!
         build = Build.where(runner_id: current_runner.id).running.find(params[:id])
-        build.update_attributes(trace: params[:trace])
+        build.update_attributes(trace: params[:trace]) if params[:trace]
 
         case params[:state].to_s
         when 'success'

--- a/spec/requests/api/builds_spec.rb
+++ b/spec/requests/api/builds_spec.rb
@@ -60,6 +60,13 @@ describe API::API do
         put api("/builds/#{build.id}"), token: runner.token
         response.status.should == 200
       end
+
+      it 'Should not override trace information when no trace is given' do
+        build.run!
+        build.update!(trace: 'hello_world')
+        put api("/builds/#{build.id}"), token: runner.token
+        expect(build.reload.trace).to eq 'hello_world'
+      end
     end
   end
 


### PR DESCRIPTION
Make sure trace attribute does not gets overriden when `params[:trace]` is not given

Fixes #295

/cc @DouweM 