### PR TITLE
Semaphore does not like real git fetching, stub out the call

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,4 @@
+# Prefer single quotes
+StringLiterals:
+  EnforcedStyle: single_quotes
+  Enabled: true

--- a/lib/upgrader.rb
+++ b/lib/upgrader.rb
@@ -41,8 +41,6 @@ class Upgrader
   end
 
   def latest_version_raw
-    git_tags = `git ls-remote --tags origin | grep tags\/v#{current_version.major}`
-    git_tags = git_tags.lines.to_a.select { |version| version =~ /v\d\.\d\.\d\Z/ }
     last_tag = git_tags.last.match(/v\d\.\d\.\d/).to_s
   end
 
@@ -90,5 +88,10 @@ class Upgrader
       answer = STDIN.gets.chomp
     end while !choices.include?(answer)
     answer
+  end
+
+  def git_tags
+    tags = `git ls-remote --tags origin | grep tags\/v#{current_version.major}`
+    tags.lines.to_a.select { |version| version =~ /v\d\.\d\.\d\Z/ }
   end
 end

--- a/spec/lib/upgrader_spec.rb
+++ b/spec/lib/upgrader_spec.rb
@@ -16,9 +16,11 @@ describe Upgrader do
   end
 
   describe 'latest_version_raw' do
-    it 'should be latest version for GitLab 5' do
-      upgrader.stub(current_version_raw: "3.0.0")
-      upgrader.latest_version_raw.should == "v3.2.0"
+    it 'should be latest version for GitLab' do
+      upgrader.stub(current_version_raw: '3.0.0')
+      upgrader.stub(git_tags: [
+        '1b5bee25b51724214c7a3307ef94027ab93ec982        refs/tags/v7.8.1'])
+      upgrader.latest_version_raw.should == 'v7.8.1'
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
The tests have been broken since a little while, this is because it looks like Semphore is blocking calls over git. In the upgrader.rb we do a git call to fetch the tags. In tests we probably dont want to really hit git.
This PR stubs out the system call to git.