### PR TITLE
Add some defaults to the web: procfile entry

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec unicorn_rails -p $PORT 
+web: bundle exec unicorn_rails -p ${PORT:="3000"} -E ${RAILS_ENV:="development"} -c ${UNICORN_CONFIG:="config/unicorn.rb"}
 worker: bundle exec sidekiq -q runner,default


### PR DESCRIPTION
**Why is this PR needed?**
In development, the `config/unicorn.rb` is not loaded using the old settings. After this change, this file is loaded when starting the app with `$ foreman start`