### PR TITLE
Get method should not have content

### DIFF
--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -7,7 +7,7 @@ class Network
 
   def authenticate(url, api_opts)
     opts = {
-      body: api_opts.to_json,
+      query: api_opts,
       headers: { "Content-Type" => "application/json" },
     }
 


### PR DESCRIPTION
GET https?://gitlab.url/api/v3/ call should not send Content-Lenght, thus body needs to be empty. Some webservers (lighttpd in my case) return 400 on GET with Content-length set.

Ngnix does not check this when proxy to gitlab backend, it just bypass.

http://tools.ietf.org/html/rfc2616#section-5.1