### PR TITLE
Jobs checking "run_for_ref" by glob pattern

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -40,7 +40,7 @@ class Job < ActiveRecord::Base
     includes = false
     # extract the refs - split by ","
     # is tricky because they can be in a regex too
-    refs.scan(/\w+|\/+.*?\/+/).map{|re| re.strip}.each do |re|
+    refs.scan(/\w+|\/+.*?\/+/).map(&:strip).each do |re|
       # is regexp or not
       if re.start_with?("/") && re.end_with?("/")
         includes = !ref.match(/#{re.delete("/")}/i).nil?
@@ -50,6 +50,6 @@ class Job < ActiveRecord::Base
 
       break if includes == true
     end
-    return includes
+    includes
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -33,23 +33,14 @@ class Job < ActiveRecord::Base
   end
 
   def run_for_ref?(ref)
-    refs.blank? || refs_include_ref?(ref)
-  end
-
-  def refs_include_ref?(ref)
-    includes = false
-    # extract the refs - split by ","
-    # is tricky because they can be in a regex too
-    refs.scan(/\w+|\/+.*?\/+/).map(&:strip).each do |re|
-      # is regexp or not
-      if re.start_with?("/") && re.end_with?("/")
-        includes = !ref.match(/#{re.delete("/")}/i).nil?
-      else
-        includes = ref == re
+    if !refs.blank?
+      refs.split(",").map(&:strip).each do |refsVal|
+        return true if File.fnmatch(refsVal, ref)
       end
 
-      break if includes == true
+      false
+    else
+      true
     end
-    includes
   end
 end

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -34,8 +34,8 @@ class Job < ActiveRecord::Base
 
   def run_for_ref?(ref)
     if !refs.blank?
-      refs.split(",").map(&:strip).each do |refsVal|
-        return true if File.fnmatch(refsVal, ref)
+      refs.split(",").map(&:strip).each do |refs_val|
+        return true if File.fnmatch(refs_val, ref)
       end
 
       false

--- a/app/views/jobs/_deploy_job_edit.html.haml
+++ b/app/views/jobs/_deploy_job_edit.html.haml
@@ -27,10 +27,14 @@
       .form-group
         = label_tag :refs, class: 'control-label' do
           Refs
-        .col-sm-10  
-          = job_form.text_field :refs, class: 'form-control', placeholder: "master, staging"
+        .col-sm-10
+          = job_form.text_field :refs, class: 'form-control', placeholder: "master, staging, /testing-v.*/"
           .help-block
             Run only when the above git refs strings match the branch or tag that was pushed.
+            %br
+            You can use RegExp like "/stable-v.*/" to match a ref like "stable-v0.1.0". The RegExp is always case insensitive.
+            %br
+            NOTE: It's important to surround you regex with "/"!
 
       .form-group
         = f.label :commands, 'Script', class: 'control-label'

--- a/app/views/jobs/_deploy_job_edit.html.haml
+++ b/app/views/jobs/_deploy_job_edit.html.haml
@@ -28,13 +28,11 @@
         = label_tag :refs, class: 'control-label' do
           Refs
         .col-sm-10
-          = job_form.text_field :refs, class: 'form-control', placeholder: "master, staging, /testing-v.*/"
+          = job_form.text_field :refs, class: 'form-control', placeholder: "master, staging, feature/*, tags/testing*"
           .help-block
             Run only when the above git refs strings match the branch or tag that was pushed.
             %br
-            You can use RegExp like "/stable-v.*/" to match a ref like "stable-v0.1.0". The RegExp is always case insensitive.
-            %br
-            NOTE: It's important to surround you regex with "/"!
+            Accepts strings and glob pattern syntax
 
       .form-group
         = f.label :commands, 'Script', class: 'control-label'

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -30,15 +30,14 @@ describe Job do
     end
 
     it "allows run for any ref in refs params" do
-      job = FactoryGirl.create :job, project: project, refs: "master, staging, /testing.*/, /^unstable$/, /unstable-v[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/"
+      job = FactoryGirl.create :job, project: project, refs: "master, staging, tags/testing*"
       job.run_for_ref?("master").should be_true
       job.run_for_ref?("staging").should be_true
-      job.run_for_ref?("staging-v0.1.0").should be_false
-      job.run_for_ref?("testing").should be_true
-      job.run_for_ref?("testing-v0.1.0").should be_true
-      job.run_for_ref?("unstable").should be_true
-      job.run_for_ref?("unstable-v0.1.0").should be_true
-      job.run_for_ref?("unstable-0.1.0").should be_false
+      job.run_for_ref?("testing").should be_false
+      job.run_for_ref?("tags/testing").should be_true
+      job.run_for_ref?("tags/testing-v0.1.0").should be_true
+      job.run_for_ref?("tags/unstable-v0.1.0").should be_false
+      job.run_for_ref?("feature/feature-one").should be_false
       job.run_for_ref?("anything").should be_false
     end
   end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -22,7 +22,7 @@ describe Job do
 
   it { should belong_to(:project) }
   it { should have_many(:builds) }
-  
+
   describe "run_for_ref?" do
     it "allows run for any ref if refs params is empty" do
       job = FactoryGirl.create :job, project: project
@@ -30,9 +30,15 @@ describe Job do
     end
 
     it "allows run for any ref in refs params" do
-      job = FactoryGirl.create :job, project: project, refs: "master, staging"
+      job = FactoryGirl.create :job, project: project, refs: "master, staging, /testing.*/, /^unstable$/, /unstable-v[0-9]{1,}.[0-9]{1,}.[0-9]{1,}/"
       job.run_for_ref?("master").should be_true
       job.run_for_ref?("staging").should be_true
+      job.run_for_ref?("staging-v0.1.0").should be_false
+      job.run_for_ref?("testing").should be_true
+      job.run_for_ref?("testing-v0.1.0").should be_true
+      job.run_for_ref?("unstable").should be_true
+      job.run_for_ref?("unstable-v0.1.0").should be_true
+      job.run_for_ref?("unstable-0.1.0").should be_false
       job.run_for_ref?("anything").should be_false
     end
   end


### PR DESCRIPTION
Regarding to [this request](https://gitlab.com/gitlab-org/gitlab-ci/issues/131) I changed the "run_for_ref" method to support ~~regular expressions~~ glob pattern like in the project settings.

Hope you like it :wink: