### PR TITLE
Add new option "cache pattern" to keep some directories in "git fetch" mode.

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -121,6 +121,7 @@ class ProjectsController < ApplicationController
     params.require(:project).permit(:path, :timeout, :timeout_in_minutes, :default_ref, :always_build,
       :polling_interval, :public, :ssh_url_to_repo, :allow_git_fetch, :skip_refs, :email_recipients,
       :email_add_pusher, :email_only_broken_builds, :coverage_regex, :shared_runners_enabled, :token,
+      :cache_pattern,
       { jobs_attributes: [:id, :name, :build_branches, :build_tags, :tag_list, :commands, :refs, :_destroy, :job_type] })
   end
 end

--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -185,6 +185,10 @@ class Build < ActiveRecord::Base
     project.allow_git_fetch
   end
 
+  def cache_pattern_list
+    project.cache_pattern_list
+  end
+
   def update_coverage
     coverage = extract_coverage(trace, project.coverage_regex)
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -165,7 +165,7 @@ ls -la
   end
 
   def cache_pattern_list
-    self.cache_pattern.split(',').map(&:strip)
+    cache_pattern.split(',').map(&:strip)
   end
 
   def cache_pattern_list=(value)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,6 +22,7 @@
 #  skip_refs                :string(255)
 #  coverage_regex           :string(255)
 #  shared_runners_enabled   :boolean          default(FALSE)
+#  cache_pattern            :string(255)      default(""), not null
 #
 
 class Project < ActiveRecord::Base
@@ -161,6 +162,14 @@ ls -la
 
   def timeout_in_minutes=(value)
     self.timeout = value.to_i * 60
+  end
+
+  def cache_pattern_list
+    self.cache_pattern.split(',').map(&:strip)
+  end
+
+  def cache_pattern_list=(value)
+    self.cache_pattern = value.join(', ')
   end
 
   def skip_ref?(ref_name)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -165,7 +165,7 @@ ls -la
   end
 
   def cache_pattern_list
-    cache_pattern.split(',').map(&:strip)
+    (cache_pattern || '').split(',').map(&:strip)
   end
 
   def cache_pattern_list=(value)

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -25,6 +25,11 @@
             %strong git fetch
             .light Faster
     .form-group
+      = f.label :cache_pattern , 'Cache pattern', class: 'control-label'
+      .col-sm-10
+        = f.text_field :cache_pattern, class: 'form-control', placeholder: 'node_modules, .tox'
+        .light Cached files will be excluded from "git clean" before "git fetch"
+    .form-group
       = f.label :timeout_in_minutes, 'Timeout', class: 'control-label'
       .col-sm-10
         = f.number_field :timeout_in_minutes, class: 'form-control', min: '0'

--- a/db/migrate/20150429072423_add_cache_pattern_to_projects.rb
+++ b/db/migrate/20150429072423_add_cache_pattern_to_projects.rb
@@ -1,0 +1,5 @@
+class AddCachePatternToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :cache_pattern, :string, :default => ""
+  end
+end

--- a/db/migrate/20150429072423_add_cache_pattern_to_projects.rb
+++ b/db/migrate/20150429072423_add_cache_pattern_to_projects.rb
@@ -1,5 +1,5 @@
 class AddCachePatternToProjects < ActiveRecord::Migration
   def change
-    add_column :projects, :cache_pattern, :string, :default => ""
+    add_column :projects, :cache_pattern, :string, default: ''
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 20150504010250) do
     t.string   "skip_refs"
     t.string   "coverage_regex"
     t.boolean  "shared_runners_enabled",   default: false
+    t.string   "cache_pattern"
   end
 
   create_table "runner_projects", force: true do |t|

--- a/lib/api/entities.rb
+++ b/lib/api/entities.rb
@@ -9,7 +9,8 @@ module API
 
     class Build < Grape::Entity
       expose :id, :commands, :path, :ref, :sha, :project_id, :repo_url,
-        :before_sha, :timeout, :allow_git_fetch, :project_name
+        :before_sha, :timeout, :allow_git_fetch, :project_name,
+        :cache_pattern_list
     end
 
     class Runner < Grape::Entity


### PR DESCRIPTION
We can cache some directories such as `node_modules` and `.tox` in order to speed up jobs building with this feature.

The related changes is here: https://github.com/gitlabhq/gitlab-ci-runner/pull/139

@gitlabhq Please review. Thanks.