### PR TITLE
Fixed issue with limits_to_mysql blocking fresh install

### DIFF
--- a/db/migrate/limits_to_mysql.rb
+++ b/db/migrate/limits_to_mysql.rb
@@ -3,6 +3,6 @@ class LimitsToMysql < ActiveRecord::Migration
     return unless ActiveRecord::Base.configurations[Rails.env]['adapter'] =~ /^mysql/
 
     change_column :builds, :trace, :text, limit: 1073741823
-    change_column :builds, :push_data, :text, limit: 16777215
+    change_column :commits, :push_data, :text, limit: 16777215
   end
 end


### PR DESCRIPTION
Guess this was lost in migrations.
It used to block fresh `rake setup`.