### PR TITLE
Renamed 'Commit duration' into 'Build duration' in Charts

### DIFF
--- a/app/views/charts/_build_times.haml
+++ b/app/views/charts/_build_times.haml
@@ -1,6 +1,6 @@
 %fieldset
   %legend
-    Build duration in minutes for last 30 commits
+    Builds duration in minutes for last 30 commits
 
   %canvas#build_timesChart.padded{width: 800, height: 300}
 

--- a/app/views/charts/_build_times.haml
+++ b/app/views/charts/_build_times.haml
@@ -1,6 +1,6 @@
 %fieldset
   %legend
-    Commit duration in minutes for last 30 commits
+    Build duration in minutes for last 30 commits
 
   %canvas#build_timesChart.padded{width: 800, height: 300}
 

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -52,6 +52,7 @@ describe "Projects" do
     it { page.should have_content 'Builds chart for last week' }
     it { page.should have_content 'Builds chart for last month' }
     it { page.should have_content 'Builds chart for last year' }
-    it { page.should have_content 'Build duration in minutes for last 30 commits' }
+    it { page.should have_content 
+         'Build duration in minutes for last 30 commits' }
   end
 end

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -52,6 +52,6 @@ describe "Projects" do
     it { page.should have_content 'Builds chart for last week' }
     it { page.should have_content 'Builds chart for last month' }
     it { page.should have_content 'Builds chart for last year' }
-    it { page.should have_content 'Commit duration in minutes for last 30 commits' }
+    it { page.should have_content 'Build duration in minutes for last 30 commits' }
   end
 end

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -52,7 +52,6 @@ describe "Projects" do
     it { page.should have_content 'Builds chart for last week' }
     it { page.should have_content 'Builds chart for last month' }
     it { page.should have_content 'Builds chart for last year' }
-    it { page.should have_content 
-         'Build duration in minutes for last 30 commits' }
+    it { page.should have_content 'Builds duration in minutes for last 30 commits' }
   end
 end


### PR DESCRIPTION
In the Charts page it makes more sense to rename "Commit duration in minutes for last 30 commits" to "Build duration in minutes for last 30 commits", since we are building commits.